### PR TITLE
Update to factory, bump dependencies

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -79,14 +79,14 @@ release:
     branch: master
   deployment:
     deploy-github:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
         bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
     deploy-maven-release:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [deploy-github]
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -30,32 +30,32 @@ build:
       owner: vaticle
       branch: master
     dependency-analysis:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
     build:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel build //...
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)')
     build-dependency:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
         bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
     # TODO: enable once the test is fixed for Java 11
     # test-client:
-    #   image: vaticle-ubuntu-21.04
+    #   image: vaticle-ubuntu-22.04
     #   command: |
     #     bazel test //client/test --test_output=errors
     deploy-maven-snapshot:
       filter:
         owner: vaticle
         branch: master
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [build, build-dependency] # TODO: make it depend on test-client once fixed
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
@@ -66,7 +66,7 @@ build:
       filter:
         owner: vaticle
         branch: master
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [deploy-maven-snapshot]
       command: |
         sed -i -e "s/FACTORY_TRACING_VERSION_MARKER/$(git rev-parse HEAD)/g" test/deployment/pom.xml
@@ -81,13 +81,10 @@ release:
     deploy-github:
       image: vaticle-ubuntu-21.04
       command: |
-        pyenv install -s 3.6.10
-        pyenv global 3.6.10 system
-        pip3 install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run @vaticle_dependencies//tool/release/notes:create -- $GRABL_OWNER $GRABL_REPO $GRABL_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
+        bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
+        bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
     deploy-maven-release:
       image: vaticle-ubuntu-21.04
       dependencies: [deploy-github]

--- a/BUILD
+++ b/BUILD
@@ -33,7 +33,7 @@ checkstyle_test(
     include = glob([
         ".bazelrc",
         ".gitignore",
-        ".grabl/automation.yml",
+        ".factory/automation.yml",
         "BUILD",
         "WORKSPACE",
         "deployment.bzl",

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -24,6 +24,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "a8b3b714a5e0562d41f4c05ca8f266d48b7d0fd3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/jamesreprise/vaticle-dependencies",
+        commit = "2f8226725810de1f352f674b228f19c460c792e7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -24,6 +24,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/jamesreprise/vaticle-dependencies",
-        commit = "2f8226725810de1f352f674b228f19c460c792e7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "4464b506ca469f37d3b696fb2f1eda34061cdaa1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )


### PR DESCRIPTION
## What is the goal of this PR?

We've updated dependencies to propagate changes that update our use of Python. See the changes: 
- https://github.com/vaticle/dependencies/pull/377

## What are the changes implemented in this PR?

We've updated:
- dependencies.
- uses of pyenv that are no longer in line with our approach.
- machine definitions from ubuntu 21.04 to 22.04.
