### PR TITLE
Re-instate use of pyenv

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -81,6 +81,12 @@ release:
     deploy-github:
       image: vaticle-ubuntu-22.04
       command: |
+        export PYENV_ROOT="/opt/pyenv"
+        pyenv install -s 3.6.10
+        pyenv global 3.6.10 system
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        python3 -m pip install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN


### PR DESCRIPTION
## What is the goal of this PR?

We've re-instated the use of pyenv in certain Factory job definitions. Removing it in favour of using the system python3 had far-reaching ramifications that proved too costly to immediately address.

## What are the changes implemented in this PR?

We've re-instated our use of pyenv in `deploy-github`.