### PR TITLE
Update release notes tool

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -89,7 +89,7 @@ release:
         sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
         python3 -m pip install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
+        bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
         bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
     deploy-maven-release:

--- a/BUILD
+++ b/BUILD
@@ -66,7 +66,6 @@ filegroup(
     name = "ci",
     data = [
         "@vaticle_dependencies//library/maven:update",
-        "@vaticle_dependencies//tool/bazelrun:rbe",
         "@vaticle_dependencies//tool/release/notes:create",
         "@vaticle_dependencies//tool/unuseddeps:unused-deps",
     ]

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,5 +25,5 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "4464b506ca469f37d3b696fb2f1eda34061cdaa1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "172c7eed134bad3dd8a2d26cfd608b11b8e3996f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )


### PR DESCRIPTION
We update dependencies so that we use the latest version of the release notes creation tool.